### PR TITLE
Implement support for server side name-generator

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -120,6 +120,12 @@ kamon {
             # name automatically or not, check the frameworks' instrumentation docs for more details.
             unhandled = "unhandled"
 
+            # FQCN for a HttpOperationNameGenerator implementation, or ony of the following shorthand forms:
+            #   - default: Uses the set default operation name
+            #   - method: Uses the request HTTP method as the operation name.
+            #
+            name-generator = "default"
+            
             # Provides custom mappings from HTTP paths into operation names. Meant to be used in cases where the bytecode
             # instrumentation is not able to provide a sensible operation name that is free of high cardinality values.
             # For example, with the following configuration:

--- a/src/main/scala/kamon/instrumentation/http/HttpClientInstrumentation.scala
+++ b/src/main/scala/kamon/instrumentation/http/HttpClientInstrumentation.scala
@@ -195,10 +195,7 @@ object HttpClientInstrumentation {
       } recover {
         case t: Throwable =>
           _log.warn("Failed to create an HTTP Operation Name Generator, falling back to the default operation name", t)
-
-          new HttpOperationNameGenerator {
-            override def name(request: HttpMessage.Request): Option[String] = Some(defaultOperationName)
-          }
+          new HttpOperationNameGenerator.Static(defaultOperationName)
       }
 
       Settings(

--- a/src/main/scala/kamon/instrumentation/http/HttpOperationNameGenerator.scala
+++ b/src/main/scala/kamon/instrumentation/http/HttpOperationNameGenerator.scala
@@ -33,4 +33,12 @@ object HttpOperationNameGenerator {
       Option(request.method)
   }
 
+  /**
+    * Uses a static name.
+    */
+  class Static(name:String) extends HttpOperationNameGenerator {
+    override def name(request: Request): Option[String] =
+      Option(name)
+  }
+
 }


### PR DESCRIPTION
This PR partially implements #2 by adding the possibility to provide a custom server-side name-generator.
Added the options:
* default - the configured default name
* method - The incoming HTTP method
* fqcn - Custom name-generator

The server side implementation pretty much mirrors the client side variant.

I say this PR implements it partially since that even though the code works as a charm the operation name  still gets overwritten at some point causing the metric to have the wrong _operation_ tag. 
I'd guess the name gets overwritten right about [here in kamon-akka-http](https://github.com/kamon-io/kamon-akka-http/blob/master/kamon-akka-http/src/main/scala-2.12/kamon/instrumentation/akka/http/AkkaHttpServerInstrumentation.scala#L188).
This looks very much like the same issue as https://github.com/kamon-io/kamon-akka-http/issues/68. 
Perhaps it's something that you @ivantopo would be willing to port to kamon 2?