### PR TITLE
HostnameAndPort

### DIFF
--- a/src/main/scala/kamon/instrumentation/http/HttpOperationNameGenerator.scala
+++ b/src/main/scala/kamon/instrumentation/http/HttpOperationNameGenerator.scala
@@ -30,7 +30,7 @@ object HttpOperationNameGenerator {
     */
   object HostnameAndPort extends HttpOperationNameGenerator {
     override def name(request: Request): Option[String] =
-      Option(request.host).map(h => s"$h${request.port}")
+      Option(request.host).map(h => s"$h:${request.port}")
   }
 
 

--- a/src/main/scala/kamon/instrumentation/http/HttpOperationNameGenerator.scala
+++ b/src/main/scala/kamon/instrumentation/http/HttpOperationNameGenerator.scala
@@ -26,7 +26,7 @@ object HttpOperationNameGenerator {
   }
  
  /**
-    * Uses the request Host to assign a name.
+    * Uses the request Host and Port to assign a name.
     */
   object HostnameAndPort extends HttpOperationNameGenerator {
     override def name(request: Request): Option[String] =

--- a/src/main/scala/kamon/instrumentation/http/HttpOperationNameGenerator.scala
+++ b/src/main/scala/kamon/instrumentation/http/HttpOperationNameGenerator.scala
@@ -24,6 +24,15 @@ object HttpOperationNameGenerator {
     override def name(request: Request): Option[String] =
       Option(request.host)
   }
+ 
+ /**
+    * Uses the request Host to assign a name.
+    */
+  object HostnameAndPort extends HttpOperationNameGenerator {
+    override def name(request: Request): Option[String] =
+      Option(request.host).map(h => s"$h${request.port}")
+  }
+
 
   /**
     * Uses the request HTTP Method to assign a name.


### PR DESCRIPTION
HostnameAndPort, like in the time of kamon 1.x (at least for Kamon-play https://github.com/kamon-io/kamon-play/blob/kamon-1.0/kamon-play-2.5.x/src/main/scala/kamon/play/Play.scala#L77)